### PR TITLE
Run django.setup() before tests for Django >= 1.7.

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
-import django
 
 urlpatterns = []
 
@@ -46,6 +45,7 @@ def runtests():
     from django.test.utils import get_runner
     TestRunner = get_runner(settings)
 
+    import django
     if django.VERSION >= (1, 7):
         django.setup()
 

--- a/runtests.py
+++ b/runtests.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
+import django
 
 urlpatterns = []
 
@@ -25,7 +26,7 @@ TEMPLATE_DIRS = [
 TEMPLATE_CONTEXT_PROCESSORS = [
     'sekizai.context_processors.sekizai',
 ]
-    
+
 
 ROOT_URLCONF = 'runtests'
 
@@ -44,6 +45,9 @@ def runtests():
     # Run the test suite, including the extra validation tests.
     from django.test.utils import get_runner
     TestRunner = get_runner(settings)
+
+    if django.VERSION >= (1, 7):
+        django.setup()
 
     test_runner = TestRunner(verbosity=1, interactive=False, failfast=False)
     failures = test_runner.run_tests(INSTALLED_APPS)


### PR DESCRIPTION
To run the tests with Django-1.7 you need to call django.setup() before anything
wants to access the App registry in a standalone script. See
https://docs.djangoproject.com/en/dev/releases/1.7/#standalone-scripts for
details.