### PR TITLE
Map processors

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -288,7 +288,6 @@ your templatetags, you can define them globally. To your ``settings.py`` add
         'css': 'myapp.sekizai_processors.preprocessor',
         ...
     }
-    # and / or
     SEKIZAI_POSTPROCESSORS = {
         ...
         'css': 'myapp.sekizai_processors.postprocessor',
@@ -296,11 +295,9 @@ your templatetags, you can define them globally. To your ``settings.py`` add
     }
 
 to map these Sekizai processors for all pre- and postprocessors using the namespace ``"css"``.
-
 It is still possible to override these global settings, by adding ``preprocessor "..."`` to a
-specific templatetag. By using the special keyword ``noprocessor``, for example
-``{% addtoblock "css" noprocessor %}``, the preset preprocessor will be deactivated for that
-specific templatetag.
+specific templatetag. By using an empty string, say ``{% addtoblock "css" preprocessor "" %}``,
+the preset preprocessor can even be deactivated for that specific templatetag.
 
 
 *******

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -288,6 +288,7 @@ your templatetags, you can define them globally. To your ``settings.py`` add
         'css': 'myapp.sekizai_processors.preprocessor',
         ...
     }
+    # and / or
     SEKIZAI_POSTPROCESSORS = {
         ...
         'css': 'myapp.sekizai_processors.postprocessor',
@@ -295,9 +296,11 @@ your templatetags, you can define them globally. To your ``settings.py`` add
     }
 
 to map these Sekizai processors for all pre- and postprocessors using the namespace ``"css"``.
+
 It is still possible to override these global settings, by adding ``preprocessor "..."`` to a
-specific templatetag. By using an empty string, say ``{% addtoblock "css" preprocessor "" %}``,
-the preset preprocessor can even be deactivated for that specific templatetag.
+specific templatetag. By using the special keyword ``noprocessor``, for example
+``{% addtoblock "css" noprocessor %}``, the preset preprocessor will be deactivated for that
+specific templatetag.
 
 
 *******

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -272,6 +272,22 @@ It's also possible to pre-process data in ``{% addtoblock %}`` like this::
 
     {% addtoblock "css" preprocessor "myapp.sekizai_processors.processor" %}
 
+To avoid the repetitive tasks of writing ``postprocessor "..."`` and/or ``preprocessor "..."`` in
+your templatetags, you can define them globally. To your ``settings.py`` add::
+
+    SEKIZAI_PROCESSORS = {
+        'pre': {
+            'css': 'myapp.sekizai_processors.preprocessor',
+        },
+        'post': {
+            'css': 'myapp.sekizai_processors.postprocessor',
+        },
+    }
+
+to map these Sekizai processors for all pre- and postprocessors using the namespace ``"css"``.
+It is still possible to override these global settings, by adding ``preprocessor "..."`` to the
+specific templatetag. By using an empty string, say ``{% addtoblock preprocessor "" %}``,
+the preset preprocessor can even be deactivated for that specific templatetag.
 
 
 *******

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -275,13 +275,15 @@ It's also possible to pre-process data in ``{% addtoblock %}`` like this::
 To avoid the repetitive tasks of writing ``postprocessor "..."`` and/or ``preprocessor "..."`` in
 your templatetags, you can define them globally. To your ``settings.py`` add::
 
-    SEKIZAI_PROCESSORS = {
-        'pre': {
-            'css': 'myapp.sekizai_processors.preprocessor',
-        },
-        'post': {
-            'css': 'myapp.sekizai_processors.postprocessor',
-        },
+    SEKIZAI_PREPROCESSORS = {
+        ...
+        'css': 'myapp.sekizai_processors.preprocessor',
+        ...
+    }
+    SEKIZAI_POSTPROCESSORS = {
+        ...
+        'css': 'myapp.sekizai_processors.postprocessor',
+        ...
     }
 
 to map these Sekizai processors for all pre- and postprocessors using the namespace ``"css"``.

--- a/sekizai/templatetags/sekizai_tags.py
+++ b/sekizai/templatetags/sekizai_tags.py
@@ -144,23 +144,19 @@ class Addtoblock(SekizaiTag):
     options = Options(
         Argument('name'),
         Flag('strip', default=False, true_values=['strip']),
-        Flag('preprocessor', default=False, true_values=['preprocessor']),
-        Flag('noprocessor', default=False, true_values=['noprocessor']),
-        Argument('procfunc', required=False, default=None, resolve=False),
+        'preprocessor',
+        Argument('preprocessor', required=False, default=None, resolve=False),
         parser_class=AddtoblockParser,
     )
 
-    def render_tag(self, context, name, strip, preprocessor, noprocessor, procfunc, nodelist):
+    def render_tag(self, context, name, strip, preprocessor, nodelist):
         rendered_contents = nodelist.render(context)
         if strip:
             rendered_contents = rendered_contents.strip()
         if preprocessor:
-            if noprocessor:
-                raise template.TemplateSyntaxError("Can not combine 'preprocessor' and 'noprocessor' inside the same templatetag: addtoblock.")
-            if preprocessor:
-                func = import_processor(procfunc)
-                rendered_contents = func(context, rendered_contents, name)
-        elif not noprocessor and name in _mapped_preprocessors:
+            func = import_processor(preprocessor)
+            rendered_contents = func(context, rendered_contents, name)
+        elif preprocessor is None and name in _mapped_preprocessors:
             rendered_contents = _mapped_preprocessors[name](context, rendered_contents, name)
         varname = get_varname()
         context[varname][name].append(rendered_contents)

--- a/sekizai/templatetags/sekizai_tags.py
+++ b/sekizai/templatetags/sekizai_tags.py
@@ -41,16 +41,14 @@ def import_processor(import_path):
     return getattr(module, object_name)
 
 
-def import_mapped_processors():
-    preprocessors, postprocessors = {}, {}
-    sekizai_processors = getattr(settings, 'SEKIZAI_PROCESSORS', {})
-    for name, processor in sekizai_processors.get('pre', {}).items():
-        preprocessors[name] = import_processor(processor)
-    for name, processor in sekizai_processors.get('post', {}).items():
-        postprocessors[name] = import_processor(processor)
-    return preprocessors, postprocessors
+def import_mapped_processors(sekizai_processors):
+    mapped_processors = {}
+    for name, processor in sekizai_processors.items():
+        mapped_processors[name] = import_processor(processor)
+    return mapped_processors
 
-_mapped_preprocessors, _mapped_postprocessors = import_mapped_processors()
+_mapped_preprocessors = import_mapped_processors(getattr(settings, 'SEKIZAI_PREPROCESSORS', {}))
+_mapped_postprocessors = import_mapped_processors(getattr(settings, 'SEKIZAI_POSTPROCESSORS', {}))
 
 
 class SekizaiParser(Parser):

--- a/sekizai/templatetags/sekizai_tags.py
+++ b/sekizai/templatetags/sekizai_tags.py
@@ -78,24 +78,23 @@ class RenderBlock(Tag):
 
     options = Options(
         Argument('name'),
-        Flag('noprocessor', default=False, true_values=['noprocessor']),
         'postprocessor',
         Argument('postprocessor', required=False, default=None, resolve=False),
         parser_class=SekizaiParser,
     )
 
-    def render_tag(self, context, name, noprocessor, postprocessor, nodelist):
+    def render_tag(self, context, name, postprocessor, nodelist):
         if not validate_context(context):
             return nodelist.render(context)
         rendered_contents = nodelist.render(context)
         varname = get_varname()
         data = context[varname][name].render()
-        if postprocessor:
-            if noprocessor:
-                raise template.TemplateSyntaxError("Can not combine 'noprocessor' and a postprocessor inside the same templatetag.")
+        if postprocessor == 'none':
+            pass
+        elif postprocessor:
             func = import_processor(postprocessor)
             data = func(context, data, name)
-        elif not noprocessor and name in _mapped_postprocessors:
+        elif name in _mapped_postprocessors:
             data = _mapped_postprocessors[name](context, data, name)
         return '%s\n%s' % (data, rendered_contents)
 register.tag(RenderBlock)
@@ -147,22 +146,21 @@ class Addtoblock(SekizaiTag):
     options = Options(
         Argument('name'),
         Flag('strip', default=False, true_values=['strip']),
-        Flag('noprocessor', default=False, true_values=['noprocessor']),
         'preprocessor',
         Argument('preprocessor', required=False, default=None, resolve=False),
         parser_class=AddtoblockParser,
     )
 
-    def render_tag(self, context, name, strip, noprocessor, preprocessor, nodelist):
+    def render_tag(self, context, name, strip, preprocessor, nodelist):
         rendered_contents = nodelist.render(context)
         if strip:
             rendered_contents = rendered_contents.strip()
-        if preprocessor:
-            if noprocessor:
-                raise template.TemplateSyntaxError("Can not combine 'noprocessor' and a preprocessor inside the same templatetag.")
+        if preprocessor == 'none':
+            pass
+        elif preprocessor:
             func = import_processor(preprocessor)
             rendered_contents = func(context, rendered_contents, name)
-        elif not noprocessor and name in _mapped_preprocessors:
+        elif name in _mapped_preprocessors:
             rendered_contents = _mapped_preprocessors[name](context, rendered_contents, name)
         varname = get_varname()
         context[varname][name].append(rendered_contents)

--- a/sekizai/templatetags/sekizai_tags.py
+++ b/sekizai/templatetags/sekizai_tags.py
@@ -1,4 +1,4 @@
-from classytags.arguments import Argument, ChoiceArgument, Flag
+from classytags.arguments import Argument, Flag
 from classytags.core import Tag, Options
 from classytags.parser import Parser
 from django import template
@@ -78,24 +78,22 @@ class RenderBlock(Tag):
 
     options = Options(
         Argument('name'),
-        ChoiceArgument('proctype', choices=['postprocessor', 'noprocessor'], required=False),
+        'postprocessor',
         Argument('postprocessor', required=False, default=None, resolve=False),
         parser_class=SekizaiParser,
     )
 
-    def render_tag(self, context, name, proctype, postprocessor, nodelist):
+    def render_tag(self, context, name, postprocessor, nodelist):
         if not validate_context(context):
             return nodelist.render(context)
         rendered_contents = nodelist.render(context)
         varname = get_varname()
         data = context[varname][name].render()
-        if proctype == 'postprocessor':
-            if postprocessor:
-                func = import_processor(postprocessor)
-                data = func(context, data, name)
-        elif proctype != 'noprocessor':
-            if name in _mapped_postprocessors:
-                data = _mapped_postprocessors[name](context, data, name)
+        if postprocessor:
+            func = import_processor(postprocessor)
+            data = func(context, data, name)
+        elif postprocessor is None and name in _mapped_postprocessors:
+            data = _mapped_postprocessors[name](context, data, name)
         return '%s\n%s' % (data, rendered_contents)
 register.tag(RenderBlock)
 
@@ -146,22 +144,20 @@ class Addtoblock(SekizaiTag):
     options = Options(
         Argument('name'),
         Flag('strip', default=False, true_values=['strip']),
-        ChoiceArgument('proctype', choices=['preprocessor', 'noprocessor'], required=False),
+        'preprocessor',
         Argument('preprocessor', required=False, default=None, resolve=False),
         parser_class=AddtoblockParser,
     )
 
-    def render_tag(self, context, name, strip, proctype, preprocessor, nodelist):
+    def render_tag(self, context, name, strip, preprocessor, nodelist):
         rendered_contents = nodelist.render(context)
         if strip:
             rendered_contents = rendered_contents.strip()
-        if proctype == 'preprocessor':
-            if preprocessor:
-                func = import_processor(preprocessor)
-                rendered_contents = func(context, rendered_contents, name)
-        elif proctype != 'noprocessor':
-            if name in _mapped_preprocessors:
-                rendered_contents = _mapped_preprocessors[name](context, rendered_contents, name)
+        if preprocessor:
+            func = import_processor(preprocessor)
+            rendered_contents = func(context, rendered_contents, name)
+        elif preprocessor is None and name in _mapped_preprocessors:
+            rendered_contents = _mapped_preprocessors[name](context, rendered_contents, name)
         varname = get_varname()
         context[varname][name].append(rendered_contents)
         return ""

--- a/sekizai/test_templates/processors/addtoblock-mappedprocessor.html
+++ b/sekizai/test_templates/processors/addtoblock-mappedprocessor.html
@@ -1,0 +1,7 @@
+{% load sekizai_tags %}
+
+{% addtoblock "mytag" %}
+mycontent
+{% endaddtoblock %}
+
+{% render_block "mytag" %}

--- a/sekizai/test_templates/processors/addtoblock-noprocessor.html
+++ b/sekizai/test_templates/processors/addtoblock-noprocessor.html
@@ -1,7 +1,7 @@
 {% load sekizai_tags %}
 
-{% addtoblock "mytag" strip noprocessor %}
+{% addtoblock "mytag" preprocessor none %}
 mycontent
 {% endaddtoblock %}
 
-{% render_block "mytag" noprocessor %}
+{% render_block "mytag" postprocessor none %}

--- a/sekizai/test_templates/processors/addtoblock-noprocessor.html
+++ b/sekizai/test_templates/processors/addtoblock-noprocessor.html
@@ -1,7 +1,7 @@
 {% load sekizai_tags %}
 
-{% addtoblock "myblock" preprocessor "" %}
+{% addtoblock "myblock" noprocessor %}
 mycontent
 {% endaddtoblock %}
 
-{% render_block "myblock" postprocessor "" %}
+{% render_block "myblock" %}

--- a/sekizai/test_templates/processors/addtoblock-noprocessor.html
+++ b/sekizai/test_templates/processors/addtoblock-noprocessor.html
@@ -1,7 +1,7 @@
 {% load sekizai_tags %}
 
-{% addtoblock "myblock" noprocessor %}
+{% addtoblock "myblock" preprocessor "" %}
 mycontent
 {% endaddtoblock %}
 
-{% render_block "myblock" %}
+{% render_block "myblock" postprocessor "" %}

--- a/sekizai/test_templates/processors/addtoblock-noprocessor.html
+++ b/sekizai/test_templates/processors/addtoblock-noprocessor.html
@@ -1,0 +1,7 @@
+{% load sekizai_tags %}
+
+{% addtoblock "myblock" preprocessor "" %}
+mycontent
+{% endaddtoblock %}
+
+{% render_block "myblock" postprocessor "" %}

--- a/sekizai/test_templates/processors/addtoblock-noprocessor.html
+++ b/sekizai/test_templates/processors/addtoblock-noprocessor.html
@@ -1,7 +1,7 @@
 {% load sekizai_tags %}
 
-{% addtoblock "myblock" preprocessor "" %}
+{% addtoblock "mytag" strip noprocessor %}
 mycontent
 {% endaddtoblock %}
 
-{% render_block "myblock" postprocessor "" %}
+{% render_block "mytag" noprocessor %}

--- a/sekizai/tests.py
+++ b/sekizai/tests.py
@@ -13,6 +13,7 @@ from sekizai.helpers import validate_template
 from sekizai.helpers import Watcher
 from sekizai.templatetags.sekizai_tags import import_processor
 from sekizai.templatetags.sekizai_tags import validate_context
+from sekizai.templatetags import sekizai_tags
 
 try:
     unicode_compat = unicode
@@ -339,22 +340,18 @@ class SekizaiTestCase(TestCase):
         self._test('processors/addtoblock_namespace.html', bits)
 
     def test_addtoblock_preprocessor_preset(self):
-        from sekizai.templatetags import sekizai_tags
-        mapped_preprocessors = sekizai_tags._mapped_preprocessors
-        sekizai_tags._mapped_preprocessors = sekizai_tags.import_mapped_processors({'myblock': 'sekizai.tests.namespace_processor'})
-        self._test('named_end.html', ['myblock'])
+        sekizai_tags._mapped_preprocessors = sekizai_tags.import_mapped_processors({'mytag': 'sekizai.tests.namespace_processor'})
+        self._test('processors/addtoblock-mappedprocessor.html', ['mytag'])
         self._test('processors/addtoblock-noprocessor.html', ['mycontent'])
-        sekizai_tags._mapped_preprocessors = mapped_preprocessors
-        self._test('named_end.html', ['mycontent'])
+        sekizai_tags._mapped_preprocessors = {}  # reset the mappings
+        self._test('processors/addtoblock-mappedprocessor.html', ['mycontent'])
 
     def test_addtoblock_postprocessor_preset(self):
-        from sekizai.templatetags import sekizai_tags
-        mapped_postprocessors = sekizai_tags._mapped_postprocessors
-        sekizai_tags._mapped_postprocessors = sekizai_tags.import_mapped_processors({'myblock': 'sekizai.tests.namespace_processor'})
-        self._test('named_end.html', ['myblock'])
+        sekizai_tags._mapped_postprocessors = sekizai_tags.import_mapped_processors({'mytag': 'sekizai.tests.namespace_processor'})
+        self._test('processors/addtoblock-mappedprocessor.html', ['mytag'])
         self._test('processors/addtoblock-noprocessor.html', ['mycontent'])
-        sekizai_tags._mapped_postprocessors = mapped_postprocessors
-        self._test('named_end.html', ['mycontent'])
+        sekizai_tags._mapped_postprocessors = {}  # reset the mappings
+        self._test('processors/addtoblock-mappedprocessor.html', ['mycontent'])
 
 
 class HelperTests(TestCase):

--- a/sekizai/tests.py
+++ b/sekizai/tests.py
@@ -338,6 +338,24 @@ class SekizaiTestCase(TestCase):
         bits = ['header', 'footer', 'js']
         self._test('processors/addtoblock_namespace.html', bits)
 
+    def test_addtoblock_preprocessor_preset(self):
+        from sekizai.templatetags import sekizai_tags
+        mapped_preprocessors = sekizai_tags._mapped_preprocessors
+        sekizai_tags._mapped_preprocessors = sekizai_tags.import_mapped_processors({'myblock': 'sekizai.tests.namespace_processor'})
+        self._test('named_end.html', ['myblock'])
+        self._test('processors/addtoblock-noprocessor.html', ['mycontent'])
+        sekizai_tags._mapped_preprocessors = mapped_preprocessors
+        self._test('named_end.html', ['mycontent'])
+
+    def test_addtoblock_postprocessor_preset(self):
+        from sekizai.templatetags import sekizai_tags
+        mapped_postprocessors = sekizai_tags._mapped_postprocessors
+        sekizai_tags._mapped_postprocessors = sekizai_tags.import_mapped_processors({'myblock': 'sekizai.tests.namespace_processor'})
+        self._test('named_end.html', ['myblock'])
+        self._test('processors/addtoblock-noprocessor.html', ['mycontent'])
+        sekizai_tags._mapped_postprocessors = mapped_postprocessors
+        self._test('named_end.html', ['mycontent'])
+
 
 class HelperTests(TestCase):
     def test_validate_template_js_css(self):


### PR DESCRIPTION
Be less repetitive when using the same preprocessor multiple times.
This should even speed up template rendering, since the processor modules are loaded only once.
For details, refer to the addition section in the docs:
https://github.com/jrief/django-sekizai/blob/map-processors/docs/index.rst#control-pre--and-postprocessors