### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Please refer to the documentation in the docs/ directory or on `RTFD <http://django-sekizai.readthedocs.org/en/latest/>`_ for help.
+Please refer to the documentation in the docs/ directory or on `RTFD <https://django-sekizai.readthedocs.io/en/latest/>`_ for help.
 
 About this project:
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.