### PR TITLE
[Django 1.10] define TEMPLATES

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -29,6 +29,19 @@ TEMPLATE_CONTEXT_PROCESSORS = [
 
 ROOT_URLCONF = 'runtests'
 
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [ os.path.join(os.path.dirname(__file__), 'sekizai', 'test_templates'), ],
+        'OPTIONS': {
+            'context_processors': [
+                'sekizai.context_processors.sekizai',
+            ],
+            'debug': True,
+        },
+    },
+]
+
 
 def runtests():
     from django import VERSION
@@ -46,6 +59,7 @@ def runtests():
         TEMPLATE_CONTEXT_PROCESSORS=TEMPLATE_CONTEXT_PROCESSORS,
         TEMPLATE_DEBUG=TEMPLATE_DEBUG,
         MIDDLEWARE_CLASSES=[],
+        TEMPLATES=TEMPLATES,
     )
     if VERSION[1] >= 7:
         from django import setup


### PR DESCRIPTION
In Django 1.10, the old TEMPLATE_* definitions are gone, and replaced by a TEMPLATE[] object, which exists since Django 1.8. This patch makes all unit test work with Django 1.10 by setting this up properly in runtests.py.