### PR TITLE
Update restrictions in documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -148,6 +148,10 @@ Restrictions
     If the ``{% addtoblock %}`` tag is used in an **extending** template, the tags **must** be
     placed within ``{% block %}...{% endblock %}`` tags.
 
+.. warning::
+
+    ``{% addtoblock %}`` tags **must not** be used in a template included with ``only`` option!
+
 Handling data
 -------------
 


### PR DESCRIPTION
`addtoblock` and `with_data` tags must not be used in a template included with only option.
Inside such a template the original context, where sekizai data is stored, is not accessible.